### PR TITLE
Fix a CMake warning about XCB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 project(xcb-imdkit VERSION 1.0.4)
 
 find_package(ECM 0.0.11 REQUIRED NO_MODULE)


### PR DESCRIPTION
This fixes a warning with the latest stable Ubuntu xcb source package.

# Before

```
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Could NOT find UTHash (missing: UTHash_INCLUDE_DIR) 
CMake Warning (dev) at /usr/share/ECM/modules/ECMFindModuleHelpers.cmake:113 (message):
  Your project should require at least CMake 3.16.0 to use FindXCB.cmake
Call Stack (most recent call first):
  /usr/share/ECM/find-modules/FindXCB.cmake:67 (ecm_find_package_version_check)
  CMakeLists.txt:46 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found XCB_XCB: /usr/lib/x86_64-linux-gnu/libxcb.so (found version "1.15") 
-- Found XCB_KEYSYMS: /usr/lib/x86_64-linux-gnu/libxcb-keysyms.so (found version "0.4.0") 
-- Found XCB_UTIL: /usr/lib/x86_64-linux-gnu/libxcb-util.so (found version "0.4.0") 
-- Found XCB: /usr/lib/x86_64-linux-gnu/libxcb.so;/usr/lib/x86_64-linux-gnu/libxcb-keysyms.so;/usr/lib/x86_64-linux-gnu/libxcb-util.so (found version "1.15") found components: XCB UTIL KEYSYMS 
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
-- The following REQUIRED packages have been found:

 * ECM (required version >= 0.0.11)
 * XCB, X protocol C-language Binding, <https://xcb.freedesktop.org/>

-- The following OPTIONAL packages have not been found:

 * UTHash

-- Configuring done
-- Generating done
-- Build files have been written to: /home/home/CLionProjects/xcb-imdkit
```

# After

```
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Could NOT find UTHash (missing: UTHash_INCLUDE_DIR) 
-- Found XCB_XCB: /usr/lib/x86_64-linux-gnu/libxcb.so (found version "1.15") 
-- Found XCB_KEYSYMS: /usr/lib/x86_64-linux-gnu/libxcb-keysyms.so (found version "0.4.0") 
-- Found XCB_UTIL: /usr/lib/x86_64-linux-gnu/libxcb-util.so (found version "0.4.0") 
-- Found XCB: /usr/lib/x86_64-linux-gnu/libxcb.so;/usr/lib/x86_64-linux-gnu/libxcb-keysyms.so;/usr/lib/x86_64-linux-gnu/libxcb-util.so (found version "1.15") found components: XCB UTIL KEYSYMS 
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
-- The following REQUIRED packages have been found:

 * ECM (required version >= 0.0.11)
 * XCB, X protocol C-language Binding, <https://xcb.freedesktop.org/>

-- The following OPTIONAL packages have not been found:

 * UTHash

-- Configuring done
-- Generating done
-- Build files have been written to: /home/home/CLionProjects/xcb-imdkit
```